### PR TITLE
Add config file

### DIFF
--- a/Data/Scripts/GameConfigHandler.gd
+++ b/Data/Scripts/GameConfigHandler.gd
@@ -1,5 +1,7 @@
 extends Node
 
+var config_file_path = Globals.config_file_path
+
 func init_config_file(path):
 	var config = ConfigFile.new()
 
@@ -9,7 +11,7 @@ func init_config_file(path):
 	# Save default values to a file
 	config.save(path)
 	
-	#Return config file instance
+	#Return ConfigFile instance
 	return config
 
 func read_config_file(config_path):
@@ -17,22 +19,39 @@ func read_config_file(config_path):
 
 	# Load config data from a file.	
 	var config_loaded = config.load(config_path)
-
+	
 	# Create default config file if it could not be read
 	if config_loaded != OK:
-		print('no config')
 		config = init_config_file(config_path)
 	
+	#Return ConfigFile instance
 	return config
 
-func save_settings():
-	#TODO - save all settings via GameSettings.get_property_list()
-	pass
+func save_config(config):
+	# Saves current settings to config file
+	
+	# Sync dictionary settings to actual in-memory values
+	GameSettings.settings = GameSettings.save_settings_to_dict()
+	
+	# Loop through all settings in the dict, saving each one ConfigFile instance
+	var _settings = GameSettings.settings
+	for section in _settings.keys():
+		for key in _settings[section].keys():
+			config.set_value(section, key, _settings[section][key])
+	
+	# Write to config file
+	config.save(config_file_path)
 	
 func apply_config(config):
-	GameSettings.locale = config.get_value("GameSettings", "locale")
+	# Set variables in GameSettings according to config file contents
+	
+	var _settings = GameSettings.settings
+	for section in _settings.keys():
+		for key in _settings[section].keys():
+			_settings[section][key] = config.get_value(section, key)
+	
+	GameSettings.load_settings_from_dict()
 
 func _init():
-	var Config = read_config_file(Globals.config_file_path)
-	apply_config(Config) 
-	print (GameSettings.locale)
+	var Config = read_config_file(config_file_path)
+	apply_config(Config)

--- a/Data/Scripts/GameConfigHandler.gd
+++ b/Data/Scripts/GameConfigHandler.gd
@@ -1,33 +1,8 @@
 extends Node
 
 var config_file_path = Globals.config_file_path
-
-func init_config_file(path):
-	var config = ConfigFile.new()
-
-	# Store default values
-	config.set_value("GameSettings", "locale", GameSettings.locale)
-
-	# Save default values to a file
-	config.save(path)
 	
-	#Return ConfigFile instance
-	return config
-
-func read_config_file(config_path):
-	var config = ConfigFile.new()
-
-	# Load config data from a file.	
-	var config_loaded = config.load(config_path)
-	
-	# Create default config file if it could not be read
-	if config_loaded != OK:
-		config = init_config_file(config_path)
-	
-	#Return ConfigFile instance
-	return config
-
-func save_config(config):
+func save_config_file(config):
 	# Saves current settings to config file
 	
 	# Sync dictionary settings to actual in-memory values
@@ -42,6 +17,19 @@ func save_config(config):
 	# Write to config file
 	config.save(config_file_path)
 	
+func load_config_file(config_path):
+	var config = ConfigFile.new()
+
+	# Load config data from a file.	
+	var config_loaded = config.load(config_path)
+	
+	# Create default config file if it could not be read
+	if config_loaded != OK:
+		save_config_file(config)
+	
+	#Return ConfigFile instance
+	return config
+
 func apply_config(config):
 	# Set variables in GameSettings according to config file contents
 	
@@ -53,5 +41,5 @@ func apply_config(config):
 	GameSettings.load_settings_from_dict()
 
 func _init():
-	var Config = read_config_file(config_file_path)
+	var Config = load_config_file(config_file_path)
 	apply_config(Config)

--- a/Data/Scripts/GameConfigHandler.gd
+++ b/Data/Scripts/GameConfigHandler.gd
@@ -1,0 +1,38 @@
+extends Node
+
+func init_config_file(path):
+	var config = ConfigFile.new()
+
+	# Store default values
+	config.set_value("GameSettings", "locale", GameSettings.locale)
+
+	# Save default values to a file
+	config.save(path)
+	
+	#Return config file instance
+	return config
+
+func read_config_file(config_path):
+	var config = ConfigFile.new()
+
+	# Load config data from a file.	
+	var config_loaded = config.load(config_path)
+
+	# Create default config file if it could not be read
+	if config_loaded != OK:
+		print('no config')
+		config = init_config_file(config_path)
+	
+	return config
+
+func save_settings():
+	#TODO - save all settings via GameSettings.get_property_list()
+	pass
+	
+func apply_config(config):
+	GameSettings.locale = config.get_value("GameSettings", "locale")
+
+func _init():
+	var Config = read_config_file(Globals.config_file_path)
+	apply_config(Config) 
+	print (GameSettings.locale)

--- a/Data/Scripts/GameSettings.gd
+++ b/Data/Scripts/GameSettings.gd
@@ -1,4 +1,28 @@
 extends Node
 
-#Settings managed by config file with default values
-export var locale = 'en'
+# This dictionary is used for synchronizing settings between config file and
+# variables in GameSettings. Also holds default values for the settings.
+var settings = {
+	'GameSettings':
+		{
+			'locale': 'en'
+		}
+	} 
+
+# Declaring global variables to hold setting values
+export var locale : String = settings['GameSettings']['locale']
+
+func load_settings_from_dict():
+	# This updates variables from settins dictionary
+	# Called after loading config file values to said dictionary
+	locale = settings['GameSettings']['locale']
+
+func save_settings_to_dict():
+	# This updates dictionary stored values from in-memory values
+	var _s = {
+		'GameSettings':
+			{
+				'locale': locale
+			}
+	}
+	return _s

--- a/Data/Scripts/GameSettings.gd
+++ b/Data/Scripts/GameSettings.gd
@@ -1,0 +1,4 @@
+extends Node
+
+#Settings managed by config file with default values
+export var locale = 'en'

--- a/Data/Scripts/Globals.gd
+++ b/Data/Scripts/Globals.gd
@@ -1,9 +1,6 @@
 extends Node
 
-
 #Player Exclusive Variables:
-
-
 export var player_gravity = -30
 export var player_max_speed = 16
 export var player_jump_height = 70
@@ -11,3 +8,6 @@ export var mouse_sensitivity = 0.002
 export var isInFirstPerson = false
 export var mouseLocked = false
 export var debug = true
+
+export var config_file_path = 'user://game_config.cfg'
+

--- a/project.godot
+++ b/project.godot
@@ -39,11 +39,14 @@ _global_script_class_icons={
 [application]
 
 config/name="insane_rpg_dev"
+run/main_scene="res://NPC.tscn"
 
 [autoload]
 
 Globals="*res://Data/Scripts/Globals.gd"
 SignalsGateway="*res://Data/Scripts/SignalsGateway.gd"
+GameSettings="*res://Data/Scripts/GameSettings.gd"
+GameConfigHandler="*res://Data/Scripts/GameConfigHandler.gd"
 
 [display]
 


### PR DESCRIPTION
Added config file, located at user://game_config.cfg. Right now there's only one parameter: locale. 

To add new settings you have to edit GameSettings.gd file:
1. Update settings dict (used to hold list of available settings and their default values)
2. Declare new var that will be used in-game as GameSettings.var_name
3. Update dict in save_settings_to_dict function (used to save in-memory settings to dict for serialization)

Current config workflow:
GameConfigHandler tries to read config on game launch. If there's no config file, it creates one with default settings. If there's a file - it loops through all available settings in GameSettings and loads their values from config file.